### PR TITLE
Spelling Fix in Keys API link

### DIFF
--- a/vimfiles/vimrcDefault
+++ b/vimfiles/vimrcDefault
@@ -27,7 +27,7 @@ logLevel = "NONE"
 --[[ ESCAPE BUTTON
 Possible values:
 	anything found in the keys api
-	http://www.comuptercraft.info/wiki/Keys_(API)
+	http://www.computercraft.info/wiki/Keys_(API)
 	But I would recommend against taking a key used for something else...
 ]]--
 escBtn = keys.tab


### PR DESCRIPTION
Never really used Github before, hopefully this works.  At this point, I'm just fixing the spelling of the suggested link for the Keys API.
